### PR TITLE
Truncates microseconds to milliseconds, if present.

### DIFF
--- a/jxmpp-core/src/main/java/org/jxmpp/util/XmppDateTime.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/util/XmppDateTime.java
@@ -95,10 +95,36 @@ public class XmppDateTime {
 			if (CONVERT_TIMEZONE) {
 				dateString = convertXep82TimezoneToRfc822(dateString);
 			}
+            if (containsMicroseconds(dateString)) {
+                dateString = removeMicroSeconds(dateString);
+            }
 			synchronized (FORMATTER) {
 				return FORMATTER.parse(dateString);
 			}
 		}
+
+        private String removeMicroSeconds(String dateString) {
+            StringBuilder outString = new StringBuilder();
+            Pattern p = Pattern.compile("(?<=\\.)\\d*(?=(Z|\\+|\\-))");
+            Matcher m = p.matcher(dateString);
+            if (m.find()) {
+                if (m.group(0).length() > 3) {
+                    int locDecimal = dateString.indexOf(".");
+                    outString.append(dateString.substring(0, locDecimal + 4));
+                    outString.append(dateString.substring(locDecimal + m.group(0).length() + 1));
+                }
+            }
+            return outString.toString();
+        }
+
+        private boolean containsMicroseconds(String dateString) {
+            boolean retVal = false;
+            String test = removeMicroSeconds(dateString);
+            if(!("".equals(test))) {
+                retVal = true;
+            }
+            return retVal;
+        }
 	}
 
 	private static final List<PatternCouplings> couplings = new ArrayList<PatternCouplings>();

--- a/jxmpp-core/src/test/java/org/jxmpp/util/XmppDateTimeTest.java
+++ b/jxmpp-core/src/test/java/org/jxmpp/util/XmppDateTimeTest.java
@@ -229,4 +229,13 @@ public class XmppDateTimeTest {
 	public void parseNoYear() throws Exception {
 		XmppDateTime.parseDate("130T23:08:25");
 	}
+
+    @Test
+    public void testParseMicroseconds() throws ParseException {
+        Date date = XmppDateTime.parseDate("2014-09-16T15:14:13.123456Z");
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.setTimeZone(TimeZone.getTimeZone("GMT"));
+        assertEquals(123,cal.get(Calendar.MILLISECOND));
+    }
 }


### PR DESCRIPTION
With regards to this thread:
https://community.igniterealtime.org/thread/53469

The Java DateFormat tools are unable to parse microseconds. XEP-0082 allows the use of microseconds. This code will truncate the microseconds field in the DateTime string to milliseconds. Test included that will fail if no fix is added.
