### PR TITLE
Return false when the arg to equals is null

### DIFF
--- a/jxmpp-jid/src/main/java/org/jxmpp/jid/parts/Part.java
+++ b/jxmpp-jid/src/main/java/org/jxmpp/jid/parts/Part.java
@@ -58,6 +58,9 @@ public abstract class Part implements CharSequence, Serializable {
 		if (this == other) {
 			return true;
 		}
+		if (other == null) {
+			return false;
+		}
 		return part.equals(other.toString());
 	}
 

--- a/jxmpp-jid/src/test/java/org/jxmpp/jid/PartTest.java
+++ b/jxmpp-jid/src/test/java/org/jxmpp/jid/PartTest.java
@@ -1,0 +1,31 @@
+/**
+ *
+ * Copyright © 2017 Ingo Bauersachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jxmpp.jid;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+import org.jxmpp.jid.parts.Part;
+
+public class PartTest {
+	@Test
+	public void testPartEqualsNullIsFalse() {
+		assertFalse(new Part("something") {
+			private static final long serialVersionUID = 0;
+		}.equals(null));
+	}
+}


### PR DESCRIPTION
Object.equals(...) says:
> For any non-null reference value x, x.equals(null) should return false.