### PR TITLE
Correctly check for slashes in domainjid parsing

### DIFF
--- a/jxmpp-core/src/main/java/org/jxmpp/util/XmppStringUtils.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/util/XmppStringUtils.java
@@ -61,7 +61,7 @@ public class XmppStringUtils {
 
 		int atIndex = jid.indexOf('@');
 		int slashIndex = jid.indexOf('/');
-		if (slashIndex > 0) {
+		if (slashIndex >= 0) {
 			// 'local@domain.foo/resource' and 'local@domain.foo/res@otherres' case
 			if (slashIndex > atIndex) {
 				return jid.substring(atIndex + 1, slashIndex);


### PR DESCRIPTION
Fixes GSO-002 by correctly checking, if domain name contains slash (also at index 0).

Edit: The patch is the solution proposed in the document.