### PR TITLE
XmppDateTime: accept `+0000` as a timezone string

### DIFF
--- a/jxmpp-core/src/main/java/org/jxmpp/util/XmppDateTime.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/util/XmppDateTime.java
@@ -40,21 +40,21 @@ public class XmppDateTime {
 	private static final Pattern datePattern = Pattern.compile("^\\d+-\\d+-\\d+$");
 
 	private static final DateFormatType timeFormatter = DateFormatType.XEP_0082_TIME_MILLIS_ZONE_PROFILE;
-	private static final Pattern timePattern = Pattern.compile("^(\\d+:){2}\\d+.\\d+(Z|([+-](\\d+:\\d+)))$");
+	private static final Pattern timePattern = Pattern.compile("^(\\d+:){2}\\d+.\\d+(Z|([+-](\\d+:?\\d+)))$");
 	private static final DateFormatType timeNoZoneFormatter = DateFormatType.XEP_0082_TIME_MILLIS_PROFILE;
 	private static final Pattern timeNoZonePattern = Pattern.compile("^(\\d+:){2}\\d+.\\d+$");
 
 	private static final DateFormatType timeNoMillisFormatter = DateFormatType.XEP_0082_TIME_ZONE_PROFILE;
-	private static final Pattern timeNoMillisPattern = Pattern.compile("^(\\d+:){2}\\d+(Z|([+-](\\d+:\\d+)))$");
+	private static final Pattern timeNoMillisPattern = Pattern.compile("^(\\d+:){2}\\d+(Z|([+-](\\d+:?\\d+)))$");
 	private static final DateFormatType timeNoMillisNoZoneFormatter = DateFormatType.XEP_0082_TIME_PROFILE;
 	private static final Pattern timeNoMillisNoZonePattern = Pattern.compile("^(\\d+:){2}\\d+$");
 
 	private static final DateFormatType dateTimeFormatter = DateFormatType.XEP_0082_DATETIME_MILLIS_PROFILE;
 	private static final Pattern dateTimePattern = Pattern
-			.compile("^\\d+(-\\d+){2}+T(\\d+:){2}\\d+.\\d+(Z|([+-](\\d+:\\d+)))$");
+			.compile("^\\d+(-\\d+){2}+T(\\d+:){2}\\d+.\\d+(Z|([+-](\\d+:?\\d+)))$");
 	private static final DateFormatType dateTimeNoMillisFormatter = DateFormatType.XEP_0082_DATETIME_PROFILE;
 	private static final Pattern dateTimeNoMillisPattern = Pattern
-			.compile("^\\d+(-\\d+){2}+T(\\d+:){2}\\d+(Z|([+-](\\d+:\\d+)))$");
+			.compile("^\\d+(-\\d+){2}+T(\\d+:){2}\\d+(Z|([+-](\\d+:?\\d+)))$");
 
 	private static final TimeZone TIME_ZONE_UTC = TimeZone.getTimeZone("UTC");
 


### PR DESCRIPTION
There was a bug in smack3 where <delay> timestamps were generated with
a timezone string of `+0000` instead of `+00:00` or `Z`.  When
processing these <delay> elements, the current parser will crash with
an "Unparseable date" exception, either bringing down the connection or
at least failing to process the <delay/> element.

This patch allows processing of both `+00:00` and `+0000` timezone
strings and correctly interpreting the time from either. While this is
not in conformance to XEP-0082, there is no damage in being liberal in
what we accept.

Signed-off-by: Georg Lukas <georg@op-co.de>