### PR TITLE
Stringprep: fix COLON to not mean COMMA

### DIFF
--- a/jxmpp-core/src/main/java/org/jxmpp/stringprep/simple/SimpleXmppStringprep.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/stringprep/simple/SimpleXmppStringprep.java
@@ -58,7 +58,7 @@ public final class SimpleXmppStringprep implements XmppStringprep {
 		'&',   // U+0026 (AMPERSAND), i.e., &
 		'\'',  // U+0027 (APOSTROPHE), i.e., '
 		'/',   // U+002F (SOLIDUS), i.e., /
-		',',   // U+003A (COLON), i.e., :
+		':',   // U+003A (COLON), i.e., :
 		'<',   // U+003C (LESS-THAN SIGN), i.e., <
 		'>',   // U+003E (GREATER-THAN SIGN), i.e., >
 		'@',   // U+0040 (COMMERCIAL AT), i.e., @


### PR DESCRIPTION
There is a tiny little typo in the localpart(?) stringprep, causing a disco#items on conference.jabber.org to fail at `,,,@conference.jabber.org` which is nevertheless a valid JID.