### PR TITLE
Prevent NPE in JidCreate.bareFrom(domainJid)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ gradle.properties
 build/
 bin/
 
+.idea/*
 *.iml
 *.ipr
 *.iws

--- a/jxmpp-jid/src/main/java/org/jxmpp/jid/impl/JidCreate.java
+++ b/jxmpp-jid/src/main/java/org/jxmpp/jid/impl/JidCreate.java
@@ -360,10 +360,10 @@ public class JidCreate {
 		String localpart = XmppStringUtils.parseLocalpart(jid);
 		String domainpart = XmppStringUtils.parseDomain(jid);
 		try {
-			if (localpart.length() != 0) {
-				bareJid = new LocalAndDomainpartJid(localpart, domainpart, context);
-			} else {
+			if (localpart == null || localpart.length() == 0) {
 				bareJid = new DomainpartJid(domainpart, context);
+			} else {
+				bareJid = new LocalAndDomainpartJid(localpart, domainpart, context);
 			}
 		} catch (XmppStringprepException e) {
 			throw new XmppStringprepException(jid, e);

--- a/jxmpp-jid/src/test/java/org/jxmpp/jid/impl/JidCreateTest.java
+++ b/jxmpp-jid/src/test/java/org/jxmpp/jid/impl/JidCreateTest.java
@@ -17,9 +17,11 @@
 package org.jxmpp.jid.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
+import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.DomainFullJid;
@@ -43,6 +45,13 @@ public class JidCreateTest {
 		} catch (XmppStringprepException e) {
 			assertEquals(notABareJid, e.getCausingString());
 		}
+	}
+
+	@Test
+	public void bareFromDomainJidTest() throws XmppStringprepException {
+		final String domainJid = "pubsub.hamlet.lit";
+		BareJid jid = JidCreate.bareFrom(domainJid);
+		assertTrue(jid instanceof DomainBareJid);
 	}
 
 	@Test


### PR DESCRIPTION
A DomainJid does not have a localpart, so `XmppStringUtils.parseLocalpart(jid)` will return null. This will case an NPE as inside the `try` block `localpart.length()` is called without checking for nullity.