### PR TITLE
gradle: Ensure git command is run projectDir rather than CWD.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -387,8 +387,9 @@ def getGitCommit() {
 	def dotGit = new File("$projectDir/.git")
 	if (!dotGit.isDirectory()) return 'non-git build'
 
+	def projectDirFile = new File("$projectDir")
 	def cmd = 'git describe --always --tags --dirty=+'
-	def proc = cmd.execute()
+	def proc = cmd.execute(null, projectDirFile)
 	def gitCommit = proc.text.trim()
 	assert !gitCommit.isEmpty()
 	gitCommit


### PR DESCRIPTION
This commit is the same change as jonathan-haubrich authored for Smack
here: https://github.com/igniterealtime/Smack/commit/7a5886279473c06d361d2903ee60f8b0eb0d13f9