### PR TITLE
Typo and NPE fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ allprojects {
 		options.compilerArgs = [
 			'-Xlint:all',
 			// Set '-options' because a non-java7 javac will emit a
-			// warning if source/traget is set to 1.7 and
+			// warning if source/target is set to 1.7 and
 			// bootclasspath is *not* set.
 			'-Xlint:-options',
 			'-Werror',
@@ -106,7 +106,7 @@ allprojects {
 	if (JavaVersion.current().isJava8Compatible()) {
 		tasks.withType(Javadoc) {
 			// The '-quiet' as second argument is actually a hack,
-			// since the one paramater addStringOption doesn't seem to
+			// since the one parameter addStringOption doesn't seem to
 			// work, we extra add '-quiet', which is added anyway by
 			// gradle.
 			options.addStringOption('Xdoclint:all', '-quiet')

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -83,7 +83,7 @@
 			<property name="ignoreComments" value="true"/>
 		</module>
 		<module name="JavadocMethod">
-			<!-- TODO stricten those checks -->
+			<!-- TODO tighten those checks -->
 			<property name="scope" value="public"/>
 		</module>
 		<module name="JavadocStyle">

--- a/jxmpp-core/src/main/java/org/jxmpp/util/XmppDateTime.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/util/XmppDateTime.java
@@ -186,7 +186,7 @@ public class XmppDateTime {
 		}
 		/*
 		 * We assume it is the XEP-0082 DateTime profile with no milliseconds at
-		 * this point. If it isn't, is is just not parseable, then we attempt to
+		 * this point. If it isn't, is is just not parsable, then we attempt to
 		 * parse it regardless and let it throw the ParseException.
 		 */
 		return dateTimeNoMillisFormatter.parse(dateString);
@@ -243,7 +243,7 @@ public class XmppDateTime {
 
 	/**
 	 * Converts a XEP-0082 date String's time zone definition into a RFC822 time
-	 * zone definition. The major difference is that XEP-0082 uses a smicolon
+	 * zone definition. The major difference is that XEP-0082 uses a semicolon
 	 * between hours and minutes and RFC822 does not.
 	 * 
 	 * @param dateString the date String.

--- a/jxmpp-core/src/main/java/org/jxmpp/util/XmppStringUtils.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/util/XmppStringUtils.java
@@ -38,7 +38,7 @@ public class XmppStringUtils {
 			return null;
 		}
 		if (atIndex == 0) {
-			// '@' as first character, i.e. '@example.org". Return emtpy string as
+			// '@' as first character, i.e. '@example.org". Return empty string as
 			// localpart, to make it possible to differentiate this from 'example.org'
 			// (which would return 'null' as localpart).
 			return "";

--- a/jxmpp-core/src/main/java/org/jxmpp/util/XmppStringUtils.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/util/XmppStringUtils.java
@@ -153,7 +153,7 @@ public class XmppStringUtils {
 				&& parseResource(jid).length() == 0;
 	}
 
-	private static final LruCache<String, String> LOCALPART_ESACPE_CACHE = new LruCache<String, String>(100);
+	private static final LruCache<String, String> LOCALPART_ESCAPE_CACHE = new LruCache<String, String>(100);
 	private static final LruCache<String, String> LOCALPART_UNESCAPE_CACHE = new LruCache<String, String>(100);
 
 	/**
@@ -194,7 +194,7 @@ public class XmppStringUtils {
 		if (localpart == null) {
 			return null;
 		}
-		String res = LOCALPART_ESACPE_CACHE.lookup(localpart);
+		String res = LOCALPART_ESCAPE_CACHE.lookup(localpart);
 		if (res != null) {
 			return res;
 		}
@@ -239,7 +239,7 @@ public class XmppStringUtils {
 			}
 		}
 		res = buf.toString();
-		LOCALPART_ESACPE_CACHE.put(localpart, res);
+		LOCALPART_ESCAPE_CACHE.put(localpart, res);
 		return res;
 	}
 

--- a/jxmpp-core/src/main/java/org/jxmpp/util/XmppStringUtils.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/util/XmppStringUtils.java
@@ -128,8 +128,10 @@ public class XmppStringUtils {
 	 * @return true if full JID, false otherwise
 	 */
 	public static boolean isFullJID(String jid) {
-		if (parseLocalpart(jid).length() <= 0 || parseDomain(jid).length() <= 0
-				|| parseResource(jid).length() <= 0) {
+		String domain = parseDomain(jid);
+		String resource = parseResource(jid);
+		if ((domain == null || domain.length() <= 0)
+				|| (resource == null || resource.length() <= 0)) {
 			return false;
 		}
 		return true;
@@ -148,9 +150,10 @@ public class XmppStringUtils {
 	 * @return true if bare JID, false otherwise
 	 */
 	public static boolean isBareJid(String jid) {
-		return parseLocalpart(jid).length() > 0
-				&& parseDomain(jid).length() > 0
-				&& parseResource(jid).length() == 0;
+		String domain = parseDomain(jid);
+		String resource = parseResource(jid);
+		return (domain != null && domain.length() > 0
+				&& (resource == null || resource.length() == 0));
 	}
 
 	private static final LruCache<String, String> LOCALPART_ESCAPE_CACHE = new LruCache<String, String>(100);

--- a/jxmpp-core/src/main/java/org/jxmpp/xml/splitter/DeclarationCallback.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/xml/splitter/DeclarationCallback.java
@@ -23,9 +23,9 @@ package org.jxmpp.xml.splitter;
 public interface DeclarationCallback {
 
 	/**
-	 * Invoked once an XML declaration got splitted.
+	 * Invoked once an XML declaration got split.
 	 *
-	 * @param declaration the declaration string that was splitted.
+	 * @param declaration the declaration string that was split.
 	 */
 	void onDeclaration(String declaration);
 

--- a/jxmpp-core/src/main/java/org/jxmpp/xml/splitter/ProcessingInstructionCallback.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/xml/splitter/ProcessingInstructionCallback.java
@@ -23,9 +23,9 @@ package org.jxmpp.xml.splitter;
 public interface ProcessingInstructionCallback {
 
 	/**
-	 * Invoked once a new XML Processing Instruction got splitted.
+	 * Invoked once a new XML Processing Instruction got split.
 	 *
-	 * @param processingInstruction the string of the splitted Processing Instruction.
+	 * @param processingInstruction the string of the split Processing Instruction.
 	 */
 	void onProcessingInstruction(String processingInstruction);
 

--- a/jxmpp-core/src/main/java/org/jxmpp/xml/splitter/XmlPrettyPrinter.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/xml/splitter/XmlPrettyPrinter.java
@@ -196,7 +196,7 @@ public class XmlPrettyPrinter extends XmlPrinter {
 		/**
 		 * Invoked after a part was completed.
 		 *
-		 * @param part the pertty printed part.
+		 * @param part the pretty printed part.
 		 */
 		void onPrettyPrintedXmlPart(StringBuilder part);
 	}
@@ -277,7 +277,7 @@ public class XmlPrettyPrinter extends XmlPrinter {
 		/**
 		 * Set a chunk callback.
 		 *
-		 * @param chunkCallback the cunk callback.
+		 * @param chunkCallback the chunk callback.
 		 * @return a reference to this builder.
 		 */
 		public Builder setChunkCallback(PrettyPrintedXmlChunkWithCurrentPartCallback chunkCallback) {

--- a/jxmpp-core/src/test/java/org/jxmpp/util/XmppStringUtilsTest.java
+++ b/jxmpp-core/src/test/java/org/jxmpp/util/XmppStringUtilsTest.java
@@ -18,6 +18,8 @@ package org.jxmpp.util;
 
 import static org.junit.Assert.assertEquals;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.jxmpp.util.XmppStringUtils.parseDomain;
 
 import org.junit.Test;
@@ -68,5 +70,23 @@ public class XmppStringUtilsTest {
 
 		// Some more advanced parsing cases
 		assertEquals(error, "resOne@resTwo", XmppStringUtils.parseResource("user@foo.jxmpp.org/resOne@resTwo"));
+	}
+
+	@Test
+	public void isFullOrBareJidTest() {
+		final String entityFullJid = "alice@wonderland.lit/rabbit_hole";
+		final String entityBareJid = "alice@wonderland.lit";
+		final String domainFullJid = "domain.part/resource";
+		final String domainBareJid = "domain.part";
+
+		assertTrue(XmppStringUtils.isFullJID(entityFullJid));
+		assertFalse(XmppStringUtils.isFullJID(entityBareJid));
+		assertTrue(XmppStringUtils.isFullJID(domainFullJid));
+		assertFalse(XmppStringUtils.isFullJID(domainBareJid));
+
+		assertFalse(XmppStringUtils.isBareJid(entityFullJid));
+		assertTrue(XmppStringUtils.isBareJid(entityBareJid));
+		assertFalse(XmppStringUtils.isBareJid(domainFullJid));
+		assertTrue(XmppStringUtils.isBareJid(domainBareJid));
 	}
 }

--- a/jxmpp-core/src/test/java/org/jxmpp/xml/splitter/XmlPrettyPrinterTest.java
+++ b/jxmpp-core/src/test/java/org/jxmpp/xml/splitter/XmlPrettyPrinterTest.java
@@ -39,9 +39,9 @@ public class XmlPrettyPrinterTest {
 				"  </i>\n" +
 				"</o>";
 		// Create an XmlPrettyPrinter.Builder with the default settings.
-		XmlPrettyPrinter.Builder xmlPrettyPrinteBuilder = XmlPrettyPrinter.builder();
+		XmlPrettyPrinter.Builder xmlPrettyPrinterBuilder = XmlPrettyPrinter.builder();
 
-		xmlPrettyPrintTest(expectedPrettyPrintedXml, inputXml, xmlPrettyPrinteBuilder);
+		xmlPrettyPrintTest(expectedPrettyPrintedXml, inputXml, xmlPrettyPrinterBuilder);
 	}
 
 	@Test
@@ -54,11 +54,11 @@ public class XmlPrettyPrinterTest {
 				"    t\n" +
 				"  </i>\n" +
 				"</o>";
-		XmlPrettyPrinter.Builder xmlPrettyPrinteBuilder = XmlPrettyPrinter
+		XmlPrettyPrinter.Builder xmlPrettyPrinterBuilder = XmlPrettyPrinter
 				.builder()
 				.setAttributeIndent(1);
 
-		xmlPrettyPrintTest(expectedPrettyPrintedXml, inputXml, xmlPrettyPrinteBuilder);
+		xmlPrettyPrintTest(expectedPrettyPrintedXml, inputXml, xmlPrettyPrinterBuilder);
 	}
 
 	@Test
@@ -70,11 +70,11 @@ public class XmlPrettyPrinterTest {
 				"\t\tt\n" +
 				"\t</i>\n" +
 				"</o>";
-		XmlPrettyPrinter.Builder xmlPrettyPrinteBuilder = XmlPrettyPrinter
+		XmlPrettyPrinter.Builder xmlPrettyPrinterBuilder = XmlPrettyPrinter
 				.builder()
 				.setTabWidth(2);
 
-		xmlPrettyPrintTest(expectedPrettyPrintedXml, inputXml, xmlPrettyPrinteBuilder);
+		xmlPrettyPrintTest(expectedPrettyPrintedXml, inputXml, xmlPrettyPrinterBuilder);
 	}
 
 	private static void xmlPrettyPrintTest(String expectedPrettyPrintedXml, String inputXml,

--- a/jxmpp-core/src/test/java/org/jxmpp/xml/splitter/XmlSplitterProcessingInstructionDeclarationCallbackTest.java
+++ b/jxmpp-core/src/test/java/org/jxmpp/xml/splitter/XmlSplitterProcessingInstructionDeclarationCallbackTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class XmlSplitterProcessingInstructionDeclarationCallbackTest extends XmlSplitterTestUtil {
 
 	@Test
-	public void sinmpleDeclarationCallbackTest() throws IOException {
+	public void simpleDeclarationCallbackTest() throws IOException {
 		SplittedPart[] splittedParts = new SplittedPart[] { decl("<?xml version='4.2' ?>"), elem("<element>foo</element>") };
 		xmppSplitterTest(splittedParts);
 	}

--- a/jxmpp-jid/src/main/java/org/jxmpp/jid/Jid.java
+++ b/jxmpp-jid/src/main/java/org/jxmpp/jid/Jid.java
@@ -66,7 +66,7 @@ import org.jxmpp.jid.parts.Resourcepart;
  * </tr>
  * </table>
  * <p>
- * You can retrieve the escaped String representing the Jid with {@link #toString()} or the unsecaped String of the JID
+ * You can retrieve the escaped String representing the Jid with {@link #toString()} or the unescaped String of the JID
  * with {@link #asUnescapedString()}.
  * </p>
  * <h2>URL Encoded JIDs</h2>

--- a/jxmpp-jid/src/main/java/org/jxmpp/jid/impl/JidCreate.java
+++ b/jxmpp-jid/src/main/java/org/jxmpp/jid/impl/JidCreate.java
@@ -674,6 +674,7 @@ public class JidCreate {
 	 * @return a JID or {@code null}
 	 * @deprecated use {@link #entityFromUnescapedOrNull(CharSequence)} instead.
 	 */
+	// TODO: remove in jxmpp 1.1
 	@Deprecated
 	public static EntityJid entityFromUnesacpedOrNull(CharSequence cs) {
 		return entityFromUnescapedOrNull(cs);

--- a/jxmpp-jid/src/main/java/org/jxmpp/jid/impl/JidCreate.java
+++ b/jxmpp-jid/src/main/java/org/jxmpp/jid/impl/JidCreate.java
@@ -672,8 +672,20 @@ public class JidCreate {
 	 *
 	 * @param cs the input {@link CharSequence}
 	 * @return a JID or {@code null}
+	 * @deprecated use {@link #entityFromUnescapedOrNull(CharSequence)} instead.
 	 */
+	@Deprecated
 	public static EntityJid entityFromUnesacpedOrNull(CharSequence cs) {
+		return entityFromUnescapedOrNull(cs);
+	}
+
+	/**
+	 * Get a {@link EntityJid} from a given {@link CharSequence} or {@code null} if the input does not represent a JID.
+	 *
+	 * @param cs the input {@link CharSequence}
+	 * @return a JID or {@code null}
+	 */
+	public static EntityJid entityFromUnescapedOrNull(CharSequence cs) {
 		try {
 			return entityFromUnescaped(cs.toString());
 		} catch (XmppStringprepException e) {

--- a/jxmpp-jid/src/main/java/org/jxmpp/jid/util/JidUtil.java
+++ b/jxmpp-jid/src/main/java/org/jxmpp/jid/util/JidUtil.java
@@ -130,11 +130,11 @@ public class JidUtil {
 			throw new NotAEntityBareJidStringException("'" + jid + "' contains multiple '@' characters");
 		}
 		final String localpart = XmppStringUtils.parseLocalpart(jid);
-		if (localpart.length() == 0) {
+		if (localpart == null || localpart.length() == 0) {
 			throw new NotAEntityBareJidStringException("'" + jid + "' has empty localpart");
 		}
 		final String domainpart = XmppStringUtils.parseDomain(jid);
-		if (domainpart.length() == 0) {
+		if (domainpart == null || domainpart.length() == 0) {
 			throw new NotAEntityBareJidStringException("'" + jid + "' has empty domainpart");
 		}
 		return JidCreate.entityBareFromUnescaped(jid);

--- a/jxmpp-jid/src/main/java/org/jxmpp/jid/util/JidUtil.java
+++ b/jxmpp-jid/src/main/java/org/jxmpp/jid/util/JidUtil.java
@@ -418,10 +418,7 @@ public class JidUtil {
 		if (jidOne != null) {
 			return jidOne.equals(jidTwo);
 		}
-		if (jidTwo != null) {
-			return jidTwo.equals(jidOne);
-		}
 
-		return jidOne == jidTwo;
+		return jidTwo == null;
 	}
 }

--- a/jxmpp-jid/src/test/java/org/jxmpp/jid/JidSerializableTest.java
+++ b/jxmpp-jid/src/test/java/org/jxmpp/jid/JidSerializableTest.java
@@ -27,12 +27,12 @@ import java.io.ObjectOutputStream;
 import org.junit.Test;
 import org.jxmpp.jid.impl.JidCreate;
 
-public class JidSerializeableTest {
+public class JidSerializableTest {
 
 	@Test
 	public void basicTest() throws IOException, ClassNotFoundException {
 		final Jid jid = JidCreate.from("foo@bar.org");
-		final Jid deserializedJid = serializeAndDeserialze(jid);
+		final Jid deserializedJid = serializeAndDeserialize(jid);
 
 		assertEquals(jid, deserializedJid);
 	}
@@ -40,33 +40,33 @@ public class JidSerializeableTest {
 	@Test
 	public void localAndDomainpartTest() throws ClassNotFoundException, IOException {
 		final EntityBareJid bareJid = JidTestUtil.BARE_JID_1;
-		final EntityBareJid deserializedBareJid = serializeAndDeserialze(bareJid);
+		final EntityBareJid deserializedBareJid = serializeAndDeserialize(bareJid);
 		assertEquals(bareJid, deserializedBareJid);
 	}
 
 	@Test
 	public void localDomainAndResourcepartTest() throws ClassNotFoundException, IOException {
 		final EntityFullJid fullJid = JidTestUtil.FULL_JID_1_RESOURCE_1;
-		final EntityFullJid deserializedFullJid = serializeAndDeserialze(fullJid);
+		final EntityFullJid deserializedFullJid = serializeAndDeserialize(fullJid);
 		assertEquals(fullJid, deserializedFullJid);
 	}
 
 	@Test
 	public void domainpartJidTest() throws ClassNotFoundException, IOException {
 		final DomainBareJid domainpartJid = JidTestUtil.DOMAIN_BARE_JID_1;
-		final DomainBareJid deserializedDomainpartJid = serializeAndDeserialze(domainpartJid);
+		final DomainBareJid deserializedDomainpartJid = serializeAndDeserialize(domainpartJid);
 		assertEquals(domainpartJid, deserializedDomainpartJid);
 	}
 
 	@Test
 	public void domainAndResourcepartTest() throws ClassNotFoundException, IOException {
 		final DomainFullJid domainFullJid = JidTestUtil.DOMAIN_FULL_JID_1;
-		final DomainFullJid deserialziedDomainFullJid = serializeAndDeserialze(domainFullJid);
-		assertEquals(domainFullJid, deserialziedDomainFullJid);
+		final DomainFullJid deserializedDomainFullJid = serializeAndDeserialize(domainFullJid);
+		assertEquals(domainFullJid, deserializedDomainFullJid);
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <S> S serializeAndDeserialze(S serializable) throws IOException, ClassNotFoundException {
+	private static <S> S serializeAndDeserialize(S serializable) throws IOException, ClassNotFoundException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		ObjectOutputStream oos = new ObjectOutputStream(baos);
 		oos.writeObject(serializable);

--- a/jxmpp-jid/src/test/java/org/jxmpp/jid/JidTest.java
+++ b/jxmpp-jid/src/test/java/org/jxmpp/jid/JidTest.java
@@ -27,7 +27,7 @@ import org.jxmpp.stringprep.XmppStringprepException;
 public class JidTest {
 
 	@Test
-	public void testJidIsPartentOf() throws XmppStringprepException {
+	public void testJidIsParentOf() throws XmppStringprepException {
 		final Jid domainBareJid = JidCreate.from("dom.example");
 		final Jid domainFullJid = JidCreate.from("dom.example/res");
 		final Jid bareJid = JidCreate.from("loc@dom.example");

--- a/jxmpp-jid/src/test/java/org/jxmpp/jid/impl/JidCreateTest.java
+++ b/jxmpp-jid/src/test/java/org/jxmpp/jid/impl/JidCreateTest.java
@@ -118,7 +118,7 @@ public class JidCreateTest {
 	}
 
 	@Test
-	public void entityFullFromUnsecapedComplexTest() throws XmppStringprepException {
+	public void entityFullFromUnescapedComplexTest() throws XmppStringprepException {
 		EntityFullJid entityFullJid = JidCreate.entityFullFromUnescaped("foo@boo@example.org/bar@baz");
 
 		Domainpart domainpart = entityFullJid.getDomain();

--- a/jxmpp-strings-testframework/src/main/java/org/jxmpp/strings/testframework/InvalidJidTestresult.java
+++ b/jxmpp-strings-testframework/src/main/java/org/jxmpp/strings/testframework/InvalidJidTestresult.java
@@ -66,7 +66,7 @@ public abstract class InvalidJidTestresult extends JidTestresult {
 				sb.append("- localpart: ").append(localpart).append('\n');
 			}
 			Domainpart domainpart = jid.getDomain();
-			sb.append("- domanipart: ").append(domainpart).append('\n');
+			sb.append("- domainpart: ").append(domainpart).append('\n');
 			Resourcepart resourcepart = jid.getResourceOrNull();
 			if (resourcepart != null) {
 				sb.append("- resourcepart: ").append(resourcepart).append('\n');

--- a/jxmpp-strings-testframework/src/main/java/org/jxmpp/strings/testframework/StringsTestframework.java
+++ b/jxmpp-strings-testframework/src/main/java/org/jxmpp/strings/testframework/StringsTestframework.java
@@ -353,7 +353,7 @@ public class StringsTestframework {
 		public final List<InvalidJidTestresult.Successful> invalidJidSuccessfulTestresults;
 		public final List<InvalidJidTestresult.Failed> invalidJidFailedTestresults;
 
-		public final boolean wasSucccessful;
+		public final boolean wasSuccessful;
 		public final int totalSuccessful;
 		public final int totalFailed;
 
@@ -376,7 +376,7 @@ public class StringsTestframework {
 
 			totalSuccessful = validJidSuccessfulTestresults.size() + invalidJidSuccessfulTestresults.size();
 			totalFailed = validJidFailedTestresults.size() + invalidJidFailedTestresults.size();
-			wasSucccessful = totalFailed == 0;
+			wasSuccessful = totalFailed == 0;
 		}
 
 		private static <I,R> List<R> gather(Collection<I> inputCollection,
@@ -401,7 +401,7 @@ public class StringsTestframework {
 					"Successful Tests: " + totalSuccessful + '\n' +
 					"Failed Tests    : " + totalFailed + '\n'
 					);
-			if (!wasSucccessful) {
+			if (!wasSuccessful) {
 				appendable.append(
 						"Some tests FAILED! :(\n");
 				for (ValidJidTestresult.Failed failed : validJidFailedTestresults) {

--- a/jxmpp-strings-testframework/src/main/java/org/jxmpp/strings/testframework/StringsTestframeworkMain.java
+++ b/jxmpp-strings-testframework/src/main/java/org/jxmpp/strings/testframework/StringsTestframeworkMain.java
@@ -55,7 +55,7 @@ public class StringsTestframeworkMain implements Callable<Integer> {
 		result.writeResults(out);
 		out.flush();
 
-		int exitcode = result.wasSucccessful ? 0 : 1;
+		int exitcode = result.wasSuccessful ? 0 : 1;
 		return exitcode;
 	}
 

--- a/jxmpp-strings-testframework/src/main/java/org/jxmpp/strings/testframework/package-info.java
+++ b/jxmpp-strings-testframework/src/main/java/org/jxmpp/strings/testframework/package-info.java
@@ -16,6 +16,6 @@
  */
 
 /**
- * A framework to test various XMPP specific string preperation libraries.
+ * A framework to test various XMPP specific string preparation libraries.
  */
 package org.jxmpp.strings.testframework;

--- a/jxmpp-util-cache/src/main/java/org/jxmpp/util/cache/ExpirationCache.java
+++ b/jxmpp-util-cache/src/main/java/org/jxmpp/util/cache/ExpirationCache.java
@@ -56,7 +56,7 @@ public class ExpirationCache<K, V> implements Cache<K, V>, Map<K, V>{
 	}
 
 	/**
-	 * Put a value in the cahce with the specified expiration time in milliseconds.
+	 * Put a value in the cache with the specified expiration time in milliseconds.
 	 *
 	 * @param key the key of the value.
 	 * @param value the value.


### PR DESCRIPTION
This PR fixes a few typos here and there, but most importantly it fixes a few NPE errors in `XmppStringUtils` and `JidUtil`.

Those were noticed, as `XmppStringUtils.isFullJid("alice@wonderland.lit")` would throw as the resource part is null but wasn't checked when `length()` was called later on.