### PR TITLE
Drop build date from manifest to make the project reproducible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ allprojects {
 	ext.sharedManifest = manifest {
 		attributes('Implementation-Version': version,
 				   'Implementation-GitRevision': ext.gitCommit,
-				   'Built-Date': ext.builtDate,
 				   'Built-JDK': System.getProperty('java.version'),
 				   'Built-Gradle': gradle.gradleVersion,
 				   'Built-By': System.getProperty('user.name')


### PR DESCRIPTION
Reproducible builds are an important way to independently verify the integrity
of the binaries. See the argument for reproducible builds[1].

The build script aims to inject a build date into manifest files of each of the
built jars. This change drops the build date from the manifest.

However, the build scripts do not seem to successfully alter the built jar
files (ext.sharedManifest is not used anywhere?). Manifest changes also seem
absent on jars published on maven repository. So, this patch only has an effect
when that is fixed. The code seems to be reproducible[2] in its current state.

Links:

1) https://reproducible-builds.org/
2) https://salsa.debian.org/sunilmohan/libjxmpp-java/-/jobs/1616871

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>