### PR TITLE
Fix ArrayOutOfBoundsException in SimpleXmppStringprep

### DIFF
--- a/jxmpp-core/src/main/java/org/jxmpp/stringprep/simple/SimpleXmppStringprep.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/stringprep/simple/SimpleXmppStringprep.java
@@ -105,7 +105,7 @@ public final class SimpleXmppStringprep implements XmppStringprep {
 			int forbiddenCharPos = Arrays.binarySearch(excludedChars, c);
 			if (forbiddenCharPos >= 0) {
 				throw new XmppStringprepException(input, parttype.getCapitalizedName() + " must not contain '"
-						+ LOCALPART_FURTHER_EXCLUDED_CHARACTERS[forbiddenCharPos] + "'");
+						+ excludedChars[forbiddenCharPos] + "'");
 			}
 		}
 	}


### PR DESCRIPTION
Simply use the same array for the message as was used in the Arrays.binarySearch call.