### PR TITLE
Fix ArrayOutOfBoundsException on localparts containing '@'.

### DIFF
--- a/jxmpp-core/src/main/java/org/jxmpp/stringprep/simple/SimpleXmppStringprep.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/stringprep/simple/SimpleXmppStringprep.java
@@ -105,7 +105,7 @@ public final class SimpleXmppStringprep implements XmppStringprep {
 			int forbiddenCharPos = Arrays.binarySearch(excludedChars, c);
 			if (forbiddenCharPos >= 0) {
 				throw new XmppStringprepException(input, parttype.getCapitalizedName() + " must not contain '"
-						+ LOCALPART_FURTHER_EXCLUDED_CHARACTERS[forbiddenCharPos] + "'");
+						+ excludedChars[forbiddenCharPos] + "'");
 			}
 		}
 	}


### PR DESCRIPTION
Because the exception error message is constructed referencing the wrong array (`LOCALPART_FURTHER_EXCLUDED_CHARACTERS` rather than `excludedChars`), when `localprep` is called with a string containing an `@`, `LOCALPART_FURTHER_EXCLUDED_CHARACTERS[8]` is referenced, causing `ArrayOutOfBoundsException` to be thrown.