### PR TITLE
Make jxmpp jars OSGi bundles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 
 	dependencies {
 		classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2"
+		classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:6.0.0"
 	}
 }
 
@@ -197,7 +198,16 @@ subprojects {
 	apply plugin: 'maven-publish'
 	apply plugin: 'signing'
 	apply plugin: 'checkstyle'
+	apply plugin: 'biz.aQute.bnd.builder'
 
+	jar {
+		bundle {
+			bnd(
+					'-removeheaders': 'Tool, Bnd-*',
+					'-exportcontents': 'org.jxmpp.*',
+			)
+		}
+	}
 	checkstyle {
 		toolVersion = '8.22'
 	}


### PR DESCRIPTION
This restores OSGi support removed in commit 619648aee730e69c9029a5109040a5c26c2567ba with a supported plugin.