### PR TITLE
entityFullFrom(String) in JidCreate.java

### DIFF
--- a/jxmpp-jid/src/main/java/org/jxmpp/jid/impl/JidCreate.java
+++ b/jxmpp-jid/src/main/java/org/jxmpp/jid/impl/JidCreate.java
@@ -1154,6 +1154,20 @@ public class JidCreate {
 		return entityFullFrom(jid.toString(), JxmppContext.getDefaultContext());
 	}
 
+
+	/* avoid method not defined exception */
+	/**
+	 * Get a {@link EntityFullJid} representing the given String.
+	 *
+	 * @param jid a CharSequence representing a JID.
+	 * @return a full JID representing the given CharSequence.
+	 * @throws XmppStringprepException if an error occurs.
+	 */
+	public static EntityFullJid entityFullFrom(String jid) throws XmppStringprepException {
+		return entityFullFrom(jid, JxmppContext.getDefaultContext());
+	}
+
+
 	/**
 	 * Get a {@link EntityFullJid} representing the given String.
 	 *


### PR DESCRIPTION
In commit c2d80be7ee12187b5b21f1d170b2d86119346e3, Feb 23.2022 of jxmpp, the function entityFullFrom was changed from: 

public static EntityFullJid entityFullFrom(String jid) throws XmppStringprepException {

to:

public static EntityFullJid entityFullFrom(String jid, JxmppContext context) throws XmppStringprepException {

this breaks Smack/BindIQProvider.java line 48:

EntityFullJid fullJid = JidCreate.entityFullFrom(parser.nextText());

nextText defined in XmlPull:
parser.nextText() returns String XmlPullParser.java:    String nextText()


What happens is a 'potentially misleading' error "SASLError using SCRAM-SHA-1: not-authorized" even though it did authenticate to XMPP server (OpenFire), going through the stack trace reveals method not found exception.
