### PR TITLE
Workaround this-escape warnings

### DIFF
--- a/jxmpp-core/src/main/java/org/jxmpp/stringprep/XmppStringprepException.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/stringprep/XmppStringprepException.java
@@ -36,6 +36,7 @@ public class XmppStringprepException extends IOException {
 	 * @param causingString the String causing the exception.
 	 * @param exception the exception.
 	 */
+	@SuppressWarnings("this-escape")
 	public XmppStringprepException(String causingString, Exception exception) {
 		super("XmppStringprepException caused by '" + causingString + "': " + exception);
 		initCause(exception);

--- a/jxmpp-util-cache/src/main/java/org/jxmpp/util/cache/ExpirationCache.java
+++ b/jxmpp-util-cache/src/main/java/org/jxmpp/util/cache/ExpirationCache.java
@@ -49,7 +49,7 @@ public class ExpirationCache<K, V> implements Cache<K, V>, Map<K, V>{
 	 *
 	 * @param defaultExpirationTime the default expiration time.
 	 */
-	public void setDefaultExpirationTime(long defaultExpirationTime) {
+	public final void setDefaultExpirationTime(long defaultExpirationTime) {
 		if (defaultExpirationTime <= 0) {
 			throw new IllegalArgumentException();
 		}


### PR DESCRIPTION
Java 21 issues this-escape warning for overridable methods that are called in the constructor.

This MR workarounds those warnings.

Note: probably it is not relevant as jxmpp uses gradle 7.6.x that does not support Java 21.
