### PR TITLE
fix: Do not setup SimpleXmppStringprep twice.

### DIFF
--- a/jxmpp-core/src/main/java/org/jxmpp/stringprep/XmppStringPrepUtil.java
+++ b/jxmpp-core/src/main/java/org/jxmpp/stringprep/XmppStringPrepUtil.java
@@ -18,16 +18,10 @@ package org.jxmpp.stringprep;
 
 import org.jxmpp.JxmppContext;
 import org.jxmpp.XmppAddressParttype;
-import org.jxmpp.stringprep.simple.SimpleXmppStringprep;
 import org.jxmpp.util.cache.Cache;
 import org.jxmpp.util.cache.LruCache;
 
 public class XmppStringPrepUtil {
-
-	static {
-		// Ensure that there is always at least the simple XMPP stringprep implementation active
-		SimpleXmppStringprep.setup();
-	}
 
 	private static final Cache<String, String> NODEPREP_CACHE = new LruCache<String, String>(100);
 	private static final Cache<String, String> DOMAINPREP_CACHE = new LruCache<String, String>(100);


### PR DESCRIPTION
JxmppContext.java already does it. Calling it from XmppStringPrepUtil can result in replacing the desired instance if it's done prior to XmppStringPrepUtil being loaded, e.g.:
```
System.err.println("Initially: " + JxmppContext.getDefaultContext().xmppStringprep.getClass().getName());
JxmppContext.setDefaultXmppStringprep(RocksXmppPrecisStringprep.INSTANCE);
System.err.println("Changed to Rocks: " + JxmppContext.getDefaultContext().xmppStringprep.getClass().getName());
try {
    JidCreate.from("example.com");
} catch(Exception e) {}
System.err.println("After parsing: " + JxmppContext.getDefaultContext().xmppStringprep.getClass().getName());
```


Results in:
```
Initially: org.jxmpp.stringprep.simple.SimpleXmppStringprep
Changed to Rocks: org.jxmpp.stringprep.rocksxmppprecis.RocksXmppPrecisStringprep
After parsing: org.jxmpp.stringprep.simple.SimpleXmppStringprep
```